### PR TITLE
Add a colortype->"perface" modifier to mesh3d

### DIFF
--- a/examples/cindy3d/Klein.html
+++ b/examples/cindy3d/Klein.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>WebGL testing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csmousedown" type="text/x-cindyscript">
+dragging=true;
+</script>
+<script id="csmouseup" type="text/x-cindyscript">
+dragging=false;
+
+</script>
+
+<script id="csinit" type="text/x-cindyscript">
+dragging=false;
+m = 50;
+n = 20;
+epsx=0.01*.1;
+epsy=0.04*.1;
+
+xx=apply((1..m),#/m);
+yy=apply(1..(n+3),#/n-1/(2*n));
+xxs=xx;
+yys=yy;
+xxp=apply(xx,#+epsx);
+xxm=apply(xx,#-epsx);
+yyp=apply(yy,#+epsy);
+yym=apply(yy,#-epsy);
+xx=sort(xx++xxp++xxm);
+yy=sort(yy++yyp++yym);
+
+ ff(x):=(
+      mm=(sin(x+pi),cos(x+pi),((cos(x+pi)+1)^5)*0.02);
+      if (mm_2*mm_2<0.000001, mm_2=0;);
+      mm;
+  );
+  gg(x):=(
+      ((cos(x+pi)+1)^4)*0.08;
+  );
+
+    ax=3.32;
+    off=pi/4+0.0132622429;
+    mat=[[0,0,-1],[0.66695951993975,0.74509395297623,0],[0.74509395297623,0.66695951993975,0]];
+
+
+tor(x,y):=(
+        x=x;
+        ww=pi*1.999999*x-.1;//Handgefrickel
+        wwc=pi*2.0*y;
+
+        xyz1=ff(ww+off);
+        xyz2=ff(ww+off+0.02);
+        xyz1=mat*xyz1;
+        xyz2=mat*xyz2;
+        xy1=(xyz1_1,xyz1_2)*3;
+        xy2=(xyz2_1,xyz2_2)*3;
+
+        xy3=xy1-xy2;
+        xy3=xy3/|xy3|;
+        xyz3=xy3++[0];
+        xyz4=(xy3_2,-xy3_1)++[0];
+        xyz1_3=0;
+        xyz2=cross(xyz3,xyz4);
+        rr=(gg(ww+off+ax)+0.25)*.4;
+        xyz=xyz1+rr*sin(wwc)*xyz4+rr*cos(wwc)*xyz2;
+        xyz*2;
+
+);
+//tor(x,y):=(x,y,1);
+
+eeps=0.00001;
+n(a,b):=(
+  t1=tor(a,b);
+  t2=tor(a+eeps,b);
+  t3=tor(a,b+eeps);
+  nn=cross(t2-t1,t3-t1);
+  nn/|nn|;
+);
+
+cols=[];
+norms=[];
+coords=[];
+coords=zerovector(length(yy)*(length(xx)+1));
+norms=zerovector(length(yy)*(length(xx)+1));
+cols=zerovector(length(yy)*(length(xx)+1));
+cnt=1;
+me():=(
+  forall(1..length(yy),j,
+   b=yy_j;
+   forall(1..length(xx), i,
+     (
+      a=xx_i;
+      cols_cnt=if(mod(i,3)==0 & mod(j,3)==0 ,(1,.6,0),(0,0,0));
+      norms_cnt=n(a,b);
+      coords_cnt=tor(a,b);
+      cnt=cnt+1;
+     );
+     );
+      a=xx_1;
+      b1=yy_(mod(-j-3+3,60)+1);
+      cols_cnt=(1,.6,0);
+      norms_cnt=-n(a,b1);
+      coords_cnt=tor(a,b1);
+      cnt=cnt+1;
+ )
+;
+);
+me();
+
+
+
+  use("Cindy3D")
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+          x=S.x;
+          if(x<S1.x,x=S1.x);
+          if(x>S2.x,x=S2.x);
+          S.xy=(x,S1.y);
+
+          x=R.x;
+          if(x<R1.x,x=R1.x);
+          if(x>R2.x,x=R2.x);
+          R.xy=(x,R1.y);
+
+
+r1 = round(|S,S1|/|S1,S2|*11);
+r2 = |R,R1|/|R1,R2|*.4+.6;
+begin3d();
+background3d((.7,.7,1));
+//shininess3d(100);
+mesh3d(length(yy), length(xx), coords,norms,  colors->cols,nomix->true, topology->"closeColumns",alpha->0.8);
+
+
+
+off=(length(xx)+1);
+kk=4*off;
+
+stripe(r):=(
+ rr=1+3*r;
+ inds=1+rr*off..kk+rr*off;
+ mesh3d(4, length(xx)+1, coords_inds,norms_inds,  colors->cols_inds,nomix->true,alpha->r2);
+);
+
+
+if(r1>10,stripe(9));
+if(r1>9,stripe(8);stripe(10));
+if(r1>8,stripe(7);stripe(11));
+if(r1>7,stripe(6);stripe(12));
+if(r1>6,stripe(5);stripe(13));
+if(r1>5,stripe(4);stripe(14));
+if(r1>4,stripe(3);stripe(15));
+if(r1>3,stripe(2);stripe(16));
+if(r1>2,stripe(1);stripe(17));
+if(r1>1,stripe(0);stripe(18));
+if(r1>0,stripe(19));
+
+
+
+end3d();
+</script>
+<script type="text/javascript">
+gslp=[
+ {name:"S1", type:"Free", pos:[-9,0],color:[0,0,0],pinned:true,size:2},
+    {name:"S2", type:"Free", pos:[0,0],color:[0,0,0],pinned:true,size:2},
+    {name:"S", type:"Free", pos:[0,0],color:[1,1,1],pinned:false,size:4},
+    {name:"l", type:"Segment", args:["S1","S2"],color:[0,0,0],pinned:false,size:2},
+   {name:"R1", type:"Free", pos:[2,0],color:[0,0,0],pinned:true,size:2},
+    {name:"R2", type:"Free", pos:[9,0],color:[0,0,0],pinned:true,size:2},
+    {name:"R", type:"Free", pos:[9,0],color:[1,1,1],pinned:false,size:4},
+    {name:"m", type:"Segment", args:["R1","R2"],color:[0,0,0],pinned:false,size:2},
+
+];
+createCindy({
+  canvasname:"CSCanvas",
+  scripts:"cs*",
+  geometry:gslp,
+ "transform": [
+        {
+          "visibleRect": [
+            -10,
+            -1,
+            10,
+            1
+          ]
+        }
+      ]
+});
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="800" height="600"></canvas>
+  <canvas id="CSCanvas" width="800" height="40" style="border:none"></canvas>
+</body>
+
+</html>

--- a/examples/cindy3d/Klein.html
+++ b/examples/cindy3d/Klein.html
@@ -131,7 +131,7 @@ r2 = |R,R1|/|R1,R2|*.4+.6;
 begin3d();
 background3d((.7,.7,1));
 //shininess3d(100);
-mesh3d(length(yy), length(xx), coords,norms,  colors->cols,nomix->true, topology->"closeColumns",alpha->0.8);
+mesh3d(length(yy), length(xx), coords, norms, colors->cols, colortype->"perface", topology->"closeColumns", alpha->0.8);
 
 
 
@@ -141,7 +141,7 @@ kk=4*off;
 stripe(r):=(
  rr=1+3*r;
  inds=1+rr*off..kk+rr*off;
- mesh3d(4, length(xx)+1, coords_inds,norms_inds,  colors->cols_inds,nomix->true,alpha->r2);
+ mesh3d(4, length(xx)+1, coords_inds, norms_inds, colors->cols_inds, colortype->"perface", alpha->r2);
 );
 
 

--- a/src/js/cindy3d/Ops3D.js
+++ b/src/js/cindy3d/Ops3D.js
@@ -358,6 +358,47 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     }
   }
 
+
+  function meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance) {
+    for (let i = 1, k = 0; i < m; ++i) {
+      for (let j = 1; j < n; ++j) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]],
+          [normals[k], normals[k + 1], normals[k + n + 1], normals[k + n]],
+          [colors[k], colors[k], colors[k], colors[k]],
+          appearance);
+        ++k;
+      }
+      if (tcr) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]],
+          [normals[k], normals[k + 1 - n], normals[k + 1], normals[k + n]],
+          [colors[k], colors[k], colors[k], colors[k]],
+          appearance);
+      }
+      ++k;
+    }
+    if (tcc) {
+      for (let j = 1; j < n; ++j) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1], pos[j], pos[j - 1]],
+          [normals[k], normals[k + 1], normals[j], normals[j - 1]],
+          [colors[k], colors[k], colors[k], colors[k]],
+          appearance);
+        ++k;
+      }
+      if (tcr) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]],
+          [normals[k], normals[k + 1 - n], normals[0], normals[n - 1]],
+          [colors[k], colors[k], colors[k], colors[k]],
+          appearance);
+      }
+    }
+  }
+
+
+
   function meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance) {
     for (let i = 1, k = 0; i < m; ++i) {
       for (let j = 1; j < n; ++j) {
@@ -403,6 +444,7 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     let normaltype = "perface";
     let topology = "open";
     let colors = null;
+    let nomix = false;
     let appearance = handleModifsAppearance(
       currentInstance.surfaceAppearance, modifs, {
         "normaltype": (a => normaltype =
@@ -410,11 +452,13 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
         "topology": (a => topology =
                        coerce.toString(a, normaltype).toLowerCase()),
         "colors": (a => colors = coerce.toList(a).map(elt => coerce.toColor(elt))),
+        "nomix": (a => nomix = coerce.toBool(a, false)),
       });
     if (pos.length !== m*n) return nada;
     if (colors !== null && colors.length !== m*n) return nada;
     let tcr = (topology === "closerows" || topology === "closeboth");
     let tcc = (topology === "closecolumns" || topology === "closeboth");
+
     let pc = null, normal = null, normalcnt = 0;
     function donormal(p1, p2) {
       let c = cross3(sub3(p1, pc), sub3(p2, pc));
@@ -427,10 +471,16 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
       let normals = coerce.toList(evaluate(args[3]))
         .map(elt => coerce.toDirection(elt));
       if (normals.length !== m*n) return nada;
-      if (colors !== null)
-        meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
-      else
+      if (colors !== null) {
+        if (nomix) {
+          meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
+        } else {
+          meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
+        }
+      }
+      else {
         meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
+      }
     } else if (normaltype === "pervertex") {
       let normals = Array(m*n);
       let mn = m*n, p = pos.map(dehom3);
@@ -449,10 +499,16 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
           normals[k++] = scale3(4./normalcnt, normal);
         }
       }
-      if (colors !== null)
-        meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
-      else
+      if (colors !== null) {
+        if (nomix) {
+          meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
+        } else {
+          meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
+        }
+      }
+      else {
         meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
+      }
     } else {
       meshAutoNormals(m, n, tcr, tcc, pos, appearance);
     }

--- a/src/js/cindy3d/Ops3D.js
+++ b/src/js/cindy3d/Ops3D.js
@@ -442,17 +442,18 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     let n = coerce.toInt(evaluate(args[1]));
     let pos = coerce.toList(evaluate(args[2])).map(elt => coerce.toHomog(elt));
     let normaltype = "perface";
+    let colortype = "pervertex";
     let topology = "open";
     let colors = null;
-    let nomix = false;
     let appearance = handleModifsAppearance(
       currentInstance.surfaceAppearance, modifs, {
         "normaltype": (a => normaltype =
                        coerce.toString(a, normaltype).toLowerCase()),
+        "colortype": (a => colortype =
+                       coerce.toString(a, colortype).toLowerCase()),
         "topology": (a => topology =
                        coerce.toString(a, normaltype).toLowerCase()),
         "colors": (a => colors = coerce.toList(a).map(elt => coerce.toColor(elt))),
-        "nomix": (a => nomix = coerce.toBool(a, false)),
       });
     if (pos.length !== m*n) return nada;
     if (colors !== null && colors.length !== m*n) return nada;
@@ -472,7 +473,7 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
         .map(elt => coerce.toDirection(elt));
       if (normals.length !== m*n) return nada;
       if (colors !== null) {
-        if (nomix) {
+        if (colortype === "perface") {
           meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
         } else {
           meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
@@ -500,7 +501,7 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
         }
       }
       if (colors !== null) {
-        if (nomix) {
+        if (colortype === "perface") {
           meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
         } else {
           meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);

--- a/src/js/cindy3d/Ops3D.js
+++ b/src/js/cindy3d/Ops3D.js
@@ -298,143 +298,59 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     return nada;
   });
 
-  function meshAutoNormals(m, n, tcr, tcc, pos, appearance) {
+  /**
+   * @param {number} m  the number of rows of the mesh
+   * @param {number} n  the number of columns of the mesh
+   * @param {boolean} tcr  whether the topology closes rows
+   * @param {boolean} tcc  whether the topology closes columns
+   * @param {!function(number, number, number, number)} callback  invoked once per mesh face
+   */
+  function iterMesh(m, n, tcr, tcc, callback) {
     for (let i = 1, k = 0; i < m; ++i) {
       for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonAutoNormal(
-          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]], appearance);
+        callback(k, k + 1, k + n + 1, k + n);
         ++k;
       }
       if (tcr) {
-        currentInstance.triangles.addPolygonAutoNormal(
-          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]], appearance);
+        callback(k, k + 1 - n, k + 1, k + n);
       }
       ++k;
     }
     if (tcc) {
       for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonAutoNormal(
-          [pos[k], pos[k + 1], pos[j], pos[j - 1]], appearance);
+        callback(k, k + 1, j, j - 1);
         ++k;
       }
       if (tcr) {
-        currentInstance.triangles.addPolygonAutoNormal(
-          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]], appearance);
+        callback(k, k + 1 - n, 0, n - 1);
       }
     }
   }
 
-  function meshWithNormals(m, n, tcr, tcc, pos, normals, appearance) {
-    for (let i = 1, k = 0; i < m; ++i) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormals(
-          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]],
-          [normals[k], normals[k + 1], normals[k + n + 1], normals[k + n]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormals(
-          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]],
-          [normals[k], normals[k + 1 - n], normals[k + 1], normals[k + n]],
-          appearance);
-      }
-      ++k;
+  /**
+   * @param {number} m  the number of rows of the mesh
+   * @param {number} n  the number of columns of the mesh
+   * @param {boolean} tcr  whether the topology closes rows
+   * @param {boolean} tcc  whether the topology closes columns
+   * @param {?Array.<number>} colors  the colors for each vertex resp. face
+   * @param {string} colortype  "pervertex" or "perface"
+   * @param {Appearance} appearance
+   */
+  function meshWithNormals(m, n, tcr, tcc, pos, normals, colors, colortype, appearance) {
+    var /** function(number, number): number */ cf; // color function
+    if (colors === null) {
+      cf = ((perface, pervertex) => appearance.color);
+    } else if (colortype === "perface") {
+      cf = ((perface, pervertex) => colors[perface]);
+    } else {
+      cf = ((perface, pervertex) => colors[pervertex]);
     }
-    if (tcc) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormals(
-          [pos[k], pos[k + 1], pos[j], pos[j - 1]],
-          [normals[k], normals[k + 1], normals[j], normals[j - 1]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormals(
-          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]],
-          [normals[k], normals[k + 1 - n], normals[0], normals[n - 1]],
-          appearance);
-      }
-    }
-  }
-
-
-  function meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance) {
-    for (let i = 1, k = 0; i < m; ++i) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]],
-          [normals[k], normals[k + 1], normals[k + n + 1], normals[k + n]],
-          [colors[k], colors[k], colors[k], colors[k]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]],
-          [normals[k], normals[k + 1 - n], normals[k + 1], normals[k + n]],
-          [colors[k], colors[k], colors[k], colors[k]],
-          appearance);
-      }
-      ++k;
-    }
-    if (tcc) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1], pos[j], pos[j - 1]],
-          [normals[k], normals[k + 1], normals[j], normals[j - 1]],
-          [colors[k], colors[k], colors[k], colors[k]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]],
-          [normals[k], normals[k + 1 - n], normals[0], normals[n - 1]],
-          [colors[k], colors[k], colors[k], colors[k]],
-          appearance);
-      }
-    }
-  }
-
-
-
-  function meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance) {
-    for (let i = 1, k = 0; i < m; ++i) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]],
-          [normals[k], normals[k + 1], normals[k + n + 1], normals[k + n]],
-          [colors[k], colors[k + 1], colors[k + n + 1], colors[k + n]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]],
-          [normals[k], normals[k + 1 - n], normals[k + 1], normals[k + n]],
-          [colors[k], colors[k + 1 - n], colors[k + 1], colors[k + n]],
-          appearance);
-      }
-      ++k;
-    }
-    if (tcc) {
-      for (let j = 1; j < n; ++j) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1], pos[j], pos[j - 1]],
-          [normals[k], normals[k + 1], normals[j], normals[j - 1]],
-          [colors[k], colors[k + 1], colors[j], colors[j - 1]],
-          appearance);
-        ++k;
-      }
-      if (tcr) {
-        currentInstance.triangles.addPolygonWithNormalsAndColors(
-          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]],
-          [normals[k], normals[k + 1 - n], normals[0], normals[n - 1]],
-          [colors[k], colors[k + 1 - n], colors[0], colors[n - 1]],
-          appearance);
-      }
-    }
+    iterMesh(m, n, tcr, tcc, (i1, i2, i3, i4) =>
+      currentInstance.triangles.addPolygonWithNormalsAndColors(
+        [pos[i1], pos[i2], pos[i3], pos[i4]],
+        [normals[i1], normals[i2], normals[i3], normals[i4]],
+        [cf(i1, i1), cf(i1, i2), cf(i1, i3), cf(i1, i4)],
+        appearance));
   }
 
   function mesh3dImpl(args, modifs) {
@@ -468,20 +384,12 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
       normal[2] += c[2];
       ++normalcnt;
     }
+
     if (args.length === 4) {
       let normals = coerce.toList(evaluate(args[3]))
         .map(elt => coerce.toDirection(elt));
       if (normals.length !== m*n) return nada;
-      if (colors !== null) {
-        if (colortype === "perface") {
-          meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
-        } else {
-          meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
-        }
-      }
-      else {
-        meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
-      }
+      meshWithNormals(m, n, tcr, tcc, pos, normals, colors, colortype, appearance);
     } else if (normaltype === "pervertex") {
       let normals = Array(m*n);
       let mn = m*n, p = pos.map(dehom3);
@@ -500,18 +408,11 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
           normals[k++] = scale3(4./normalcnt, normal);
         }
       }
-      if (colors !== null) {
-        if (colortype === "perface") {
-          meshWithNormalsAndColorsNoMix(m, n, tcr, tcc, pos, normals, colors, appearance);
-        } else {
-          meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
-        }
-      }
-      else {
-        meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
-      }
+      meshWithNormals(m, n, tcr, tcc, pos, normals, colors, colortype, appearance);
     } else {
-      meshAutoNormals(m, n, tcr, tcc, pos, appearance);
+      iterMesh(m, n, tcr, tcc, (i1, i2, i3, i4) =>
+        currentInstance.triangles.addPolygonAutoNormal(
+          [pos[i1], pos[i2], pos[i3], pos[i4]], appearance));
     }
     return nada;
   };


### PR DESCRIPTION
Sometimes it is desirable to apply a solid color to a whole face of a mesh, as opposed to interpolating colors between vertices. This patch here introduces the notation `colortype->"perface"` for that case. It is based on a `nomix->true` modifier by @richter-gebert, with modifications for consistency and code deduplication.
